### PR TITLE
Added use-hostname option

### DIFF
--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"github.com/couchbaselabs/cbdynclusterd/daemon"
+	"github.com/spf13/cobra"
+)
+
+var refreshCmd = &cobra.Command{
+	Use:   "refresh <cluster_id> <timeout>",
+	Short: "Updates timeout of the cluster",
+	Long: "Timeout is in duration format of Golang which is possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as \"300s\", \"+1.5h\" or \"2h25m\"",
+	Args: cobra.MinimumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		checkConfigInitialized()
+
+		clusterId := args[0]
+		_, err := getCluster(clusterId)
+		if err != nil {
+			fmt.Printf("Failed to find the cluster %s: %s\n", clusterId, err)
+			os.Exit(1)
+		}
+
+		var reqData daemon.RefreshJSON
+		reqData.Timeout = args[1]
+		err = serverRestCall("PUT", "/cluster/"+clusterId, reqData, nil, false)
+		if err != nil {
+			fmt.Printf("Failed to refresh cluster %s: %s\n", clusterId, err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(refreshCmd)
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -24,12 +24,14 @@ var setupCmd = &cobra.Command{
 		var nodes []string
 		var err error
 		var storageMode, bucketOption, userOption string
+		var useHostname bool
 		var ramQuota int
 		if nodes, err = flags.GetStringArray("node"); err != nil { printAndExit("Invalid node") }
 		if storageMode, err = cmd.Flags().GetString("storage-mode"); err != nil { printAndExit("Invalid storage-mode")}
 		if ramQuota, err = cmd.Flags().GetInt("ram-quota"); err != nil { printAndExit("Invalid ram-quota")}
 		if bucketOption, err = cmd.Flags().GetString("bucket"); err != nil { printAndExit("Invalid bucket option")}
 		if userOption, err = cmd.Flags().GetString("user"); err != nil { printAndExit("Invalid user option")}
+		if useHostname, err = cmd.Flags().GetBool("use-hostname"); err != nil { printAndExit("Invalid use-hostname option")}
 
 
 
@@ -39,6 +41,7 @@ var setupCmd = &cobra.Command{
 		}
 		reqData.RamQuota = ramQuota
 		reqData.StorageMode = storageMode
+		reqData.UseHostname = useHostname
 		reqData.Bucket = parseBucketOption(bucketOption)
 		reqData.User   = parseUserOption(userOption)
 
@@ -109,4 +112,5 @@ func init() {
 	setupCmd.Flags().Int("ram-quota", 600, "ram quota")
 	setupCmd.Flags().String("bucket", "", "Create a bucket <bucket-name>[:<bucket-type, memcached|couchbase|ephemeral[:<bucket password>]]. if only bucket name is given, couchbase bucket will be created. if server is equal or after 5.0, bucket password will be ignored")
 	setupCmd.Flags().String("user", "", "Create a user <user-name>:<user-password>[:<user-role>]. creates a user. default role is admin")
+	setupCmd.Flags().Bool("use-hostname", false, "Set true to setup a cluster using hostname. default is false")
 }


### PR DESCRIPTION
use-hostname option is added to allow server added by hostname instead of IP. Main use case is to test TLS allowed by hostname
