### PR TITLE
Resolving go mod reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/cbdyncluster
 go 1.13
 
 require (
-	github.com/couchbaselabs/cbdynclusterd v1.1.3-0.20200727174522-e4cb2d090807
+	github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20201125004146-4eabef473114
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/couchbaselabs/cbcerthelper v0.0.0-20200412115917-6e604a2b10e8 h1:3llI
 github.com/couchbaselabs/cbcerthelper v0.0.0-20200412115917-6e604a2b10e8/go.mod h1:P+HDRid9bLCl+jwGEinhLZ0FAbzmGTw+o4TZeYIBhCs=
 github.com/couchbaselabs/cbdynclusterd v1.1.3-0.20200727174522-e4cb2d090807 h1:iJTzNfbXjx1eX7K0GRKuQYiJ1C1UZRW7Yd7tmeJTFAI=
 github.com/couchbaselabs/cbdynclusterd v1.1.3-0.20200727174522-e4cb2d090807/go.mod h1:dEplxDQfWPjdFoqWAE5Da4H6mzilNaFPxQpTNQ8/Gp0=
+github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20201125004146-4eabef473114 h1:CboIUT50/B6LDMwBx2A83ek5bu5ZSfmFylzyqeKRuqM=
+github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20201125004146-4eabef473114/go.mod h1:dEplxDQfWPjdFoqWAE5Da4H6mzilNaFPxQpTNQ8/Gp0=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=


### PR DESCRIPTION
The earlier commit on this repo needed to refer to the latest commit in cbdynclusterd. This commit updates the go.mod and go.sum to reflect to the latest commit i.e "4eabef473114" in cbdynclusterd.