### PR TITLE
Update actions file with latest setup-go version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2.1.3
         with:
-          go-version: ^1.13.1
+          go-version: ^1.13.6
       - name: Build project
         run: |
           GOOS=darwin GOARCH=amd64 go build -o cbdyncluster-macos


### PR DESCRIPTION
Needed due to deprecation of [set-env](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands). Fixed in [v2.1.3](https://github.com/actions/setup-go/releases/tag/v2.1.3) of setup-go.