### PR TITLE
SDKQE-2713: Support predefined environments for capella clusters

### DIFF
--- a/cmd/create-cloud.go
+++ b/cmd/create-cloud.go
@@ -29,7 +29,7 @@ var createCloudCmd = &cobra.Command{
 		var singleAZ *bool
 		var image string
 		var overrideToken string
-		var serverVersion string
+		var env string
 		var err error
 		if nodes, err = flags.GetStringArray("node"); err != nil {
 			printAndExit("Invalid node")
@@ -77,8 +77,8 @@ var createCloudCmd = &cobra.Command{
 		if overrideToken, err = flags.GetString("override-token"); err != nil {
 			printAndExit("Invalid override token")
 		}
-		if serverVersion, err = flags.GetString("server-version"); err != nil {
-			printAndExit("Invalid server version")
+		if env, err = flags.GetString("env"); err != nil {
+			printAndExit("Invalid env")
 		}
 
 		if url != "" {
@@ -90,9 +90,7 @@ var createCloudCmd = &cobra.Command{
 				SecretKey:     secretKey,
 				Username:      username,
 				Password:      password,
-				Image:         image,
 				OverrideToken: overrideToken,
-				ServerVersion: serverVersion,
 			}
 		}
 
@@ -102,6 +100,14 @@ var createCloudCmd = &cobra.Command{
 
 		if provider != "" {
 			reqData.Provider = provider
+		}
+
+		if image != "" {
+			reqData.Image = image
+		}
+
+		if env != "" {
+			reqData.EnvName = env
 		}
 
 		reqData.SingleAZ = singleAZ
@@ -133,5 +139,5 @@ func init() {
 	createCloudCmd.Flags().Bool("single-az", true, "Only deploy in one availability zone")
 	createCloudCmd.Flags().String("image", "", "Custom image e.g. couchbase-cloud-server-7.2.0-1409-qe")
 	createCloudCmd.Flags().String("override-token", "", "Override token to use non default deployment options")
-	createCloudCmd.Flags().String("server-version", "", "Custom server version e.g. 7.1.0")
+	createCloudCmd.Flags().String("env", "", "Predefined environment (e.g. prod, stage, dev)")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbaselabs/cbdyncluster
 go 1.13
 
 require (
-	github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220629151512-27a083a13440
+	github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220711090703-e2d70c7b5cfb
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pelletier/go-toml v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -56,8 +57,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/couchbaselabs/cbcerthelper v0.0.0-20220203115212-3b5fe2d4c5e2 h1:icJd8gbKK/qoP7wT8/vYXe2Sy8/4DebrsyjeImT6cxo=
 github.com/couchbaselabs/cbcerthelper v0.0.0-20220203115212-3b5fe2d4c5e2/go.mod h1:P+HDRid9bLCl+jwGEinhLZ0FAbzmGTw+o4TZeYIBhCs=
-github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220629151512-27a083a13440 h1:kw8MafwOJdDCo7HfMRXOxA61mx16JEYTgoNtICXacGk=
-github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220629151512-27a083a13440/go.mod h1:QEWh1Sc6AovN3AcVqh1UiOQSpRtmthF4L500bcr5eZ8=
+github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220711090703-e2d70c7b5cfb h1:6VVNQTn4IrEernRL4PnJfxgKeyNnbrXN6xeV9JTvWm0=
+github.com/couchbaselabs/cbdynclusterd v1.1.4-0.20220711090703-e2d70c7b5cfb/go.mod h1:nW1OvMHH9qIhA0f4BuAEneOobY1IjQtni2RZfdmw0gs=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -188,7 +189,6 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -236,7 +236,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
-github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.6.3 h1:pDDu1OyEDTKzpJwdq4TiuLyMsUgRa/BT5cn5O62NoHs=
 github.com/spf13/viper v1.6.3/go.mod h1:jUMtyi0/lB5yZH/FjyGAoH7IMNrIhlBf6pXZmbMDvzw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Removed the --server-version argument, it is now inferred server side
Added a new --env arg that uses a predefined capella environment (currently dev, stage and prod)