### PR TITLE
Use server default for bucket storage backend

### DIFF
--- a/cmd/bucket.go
+++ b/cmd/bucket.go
@@ -54,10 +54,6 @@ var addBucketCmd = &cobra.Command{
 			printAndExit("Invalid width")
 		}
 
-		if storageBackend == "magma" && ramQuota < 256 {
-			printAndExit("Magma buckets require quota >= 256MB")
-		}
-
 		var reqData daemon.AddBucketJSON
 
 		reqData.RamQuota = ramQuota
@@ -88,7 +84,7 @@ func init() {
 	addBucketCmd.Flags().Int("replica-count", 1, "number of replicas")
 	addBucketCmd.Flags().Bool("use-hostname", false, "set true to setup a cluster using hostname. default is false")
 	addBucketCmd.Flags().String("eviction-Policy", "", "eviction-Policy for the bucket")
-	addBucketCmd.Flags().String("storage-backend", "couchstore", "storage-backend for the bucket")
+	addBucketCmd.Flags().String("storage-backend", "", "storage-backend for the bucket")
 	addBucketCmd.Flags().Int("num-vbuckets", 0, "number of vbuckets (only supported in serverless mode)")
 	addBucketCmd.Flags().Int("width", 0, "width of the bucket (only supported in serverless mode)")
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -120,8 +120,6 @@ func parseBucketOption(opt string) *helper.BucketOption {
 	}
 	if len(parsed) > 3 {
 		storageBackend = parsed[3]
-	} else {
-		storageBackend = "couchstore"
 	}
 
 	return &helper.BucketOption{
@@ -143,7 +141,7 @@ func init() {
 	setupCmd.Flags().StringArray("node", nil, "Comma separated services.")
 	setupCmd.Flags().String("storage-mode", "", "set storage mode")
 	setupCmd.Flags().Int("ram-quota", 600, "ram quota")
-	setupCmd.Flags().String("bucket", "", "Create a bucket <bucket-name>[:<bucket-type, memcached|couchbase|ephemeral[:<bucket password>]][:<storage backend, couchstore|magma>]. if only bucket name is given, couchbase bucket will be created. if server is equal or after 5.0, bucket password will be ignored. Storage backend defaults to couchstore")
+	setupCmd.Flags().String("bucket", "", "Create a bucket <bucket-name>[:<bucket-type, memcached|couchbase|ephemeral[:<bucket password>]][:<storage backend, couchstore|magma>]. if only bucket name is given, couchbase bucket will be created. if server is equal or after 5.0, bucket password will be ignored. Storage backend defaults to the server default.")
 	setupCmd.Flags().String("user", "", "Create a user <user-name>:<user-password>[:<user-role>]. creates a user. default role is admin")
 	setupCmd.Flags().Bool("use-hostname", false, "Set true to setup a cluster using hostname. default is false")
 	setupCmd.Flags().Bool("enable-developer-preview", false, "Set true to enable developer preview. default is false")


### PR DESCRIPTION
We shouldn't set the storage backend to couchstore if it's not been specified. We should rely to the server default instead, so that magma buckets are created by default in Morpheus.